### PR TITLE
Multiple log expected in retry cases

### DIFF
--- a/Testcase4-Application-breakdown/image-process/src/handler/src/main/java/org/ipads/Handler.java
+++ b/Testcase4-Application-breakdown/image-process/src/handler/src/main/java/org/ipads/Handler.java
@@ -64,6 +64,7 @@ public class Handler {
         commTimes.add(0);
         response.add("commTimes", commTimes);
 
+        // Multiple logs are expected in retry cases
         try {
             String imageName = args.get(ImageProcessCommons.IMAGE_NAME).getAsString();
             Database db = ClientBuilder.url(new URL(couchdb_url))


### PR DESCRIPTION
Add a comment explaining that in Testcase4-image-process, multiple logs are expected in retrying cases.